### PR TITLE
 Detect changes in external modules' subpackages 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: utilitywarehouse/setup-go@main
+      - uses: utilitywarehouse/actions-go/setup@main
         with:
           go-version: '^1.17'
       - name: Lint
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: utilitywarehouse/setup-go@main
+      - uses: utilitywarehouse/actions-go/setup@main
         with:
           go-version: '^1.17'
       - name: test

--- a/patrol/patrol_test.go
+++ b/patrol/patrol_test.go
@@ -35,8 +35,6 @@ func (test *RepoTest) Run(t *testing.T) {
 	tmp, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	fmt.Println(tmp)
-
 	// init repo
 	repo, err := git.PlainInit(tmp, false)
 	require.NoError(t, err)
@@ -105,7 +103,9 @@ type RepoTests []RepoTest
 
 func (tests RepoTests) Run(t *testing.T) {
 	for _, test := range tests {
-		test.Run(t)
+		t.Run(test.Name, func(t *testing.T) {
+			test.Run(t)
+		})
 	}
 }
 

--- a/patrol/repo.go
+++ b/patrol/repo.go
@@ -155,7 +155,7 @@ func (r *Repo) addPackage(path string, imports []string) {
 		// if the dependency is part of an external dependency (defined in go.mod)
 		// add the parent module as a dependency as well so that a simple version
 		// change would mark this package as changed
-		if parent, ok := r.isGoMod(dependency); ok {
+		if parent, ok := r.externalModule(dependency); ok {
 			if _, alreadyProcessed := alreadyProcessedImports[parent]; alreadyProcessed {
 				continue
 			}
@@ -165,10 +165,10 @@ func (r *Repo) addPackage(path string, imports []string) {
 	}
 }
 
-// isGoMod checks if the given package is part of one of the modules required
+// externalModule checks if the given package is part of one of the modules required
 // as dependencies in go.mod. If it is it returns the name of the parent
 // package and true.
-func (r *Repo) isGoMod(pkg string) (string, bool) {
+func (r *Repo) externalModule(pkg string) (string, bool) {
 	for _, req := range r.Module.Require {
 		if strings.HasPrefix(pkg, req.Mod.Path) {
 			return req.Mod.Path, true

--- a/patrol/repo.go
+++ b/patrol/repo.go
@@ -151,7 +151,30 @@ func (r *Repo) addPackage(path string, imports []string) {
 		}
 		r.addDependant(pkg, dependency)
 		alreadyProcessedImports[dependency] = struct{}{}
+
+		// if the dependency is part of an external dependency (defined in go.mod)
+		// add the parent module as a dependency as well so that a simple version
+		// change would mark this package as changed
+		if parent, ok := r.isGoMod(dependency); ok {
+			if _, alreadyProcessed := alreadyProcessedImports[parent]; alreadyProcessed {
+				continue
+			}
+			r.addDependant(pkg, parent)
+			alreadyProcessedImports[parent] = struct{}{}
+		}
 	}
+}
+
+// isGoMod checks if the given package is part of one of the modules required
+// as dependencies in go.mod. If it is it returns the name of the parent
+// package and true.
+func (r *Repo) isGoMod(pkg string) (string, bool) {
+	for _, req := range r.Module.Require {
+		if strings.HasPrefix(pkg, req.Mod.Path) {
+			return req.Mod.Path, true
+		}
+	}
+	return "", false
 }
 
 // addDependant adds dependant as one of the dependants of the package

--- a/patrol/repo_test.go
+++ b/patrol/repo_test.go
@@ -34,6 +34,12 @@ func TestRepo(t *testing.T) {
 			Description: "A change to a go modules dependency\n" +
 				"should flag depending packages as changed",
 		},
+		RepoTest{
+			TestdataFolder: "alias",
+			Name:           "change in go modules dependency that was aliased",
+			Description: "A change to a go modules dependency\n" +
+				"should flag depending packages as changed",
+		},
 	}
 
 	tests.Run(t)

--- a/patrol/repo_test.go
+++ b/patrol/repo_test.go
@@ -28,6 +28,12 @@ func TestRepo(t *testing.T) {
 			Description: "A change to package x that is being tested " +
 				"using x_test package should not result in a stack overflow :D",
 		},
+		RepoTest{
+			TestdataFolder: "submodules",
+			Name:           "change in go modules dependency sub package",
+			Description: "A change to a go modules dependency\n" +
+				"should flag depending packages as changed",
+		},
 	}
 
 	tests.Run(t)

--- a/patrol/testdata/alias/commits/1/go.mod
+++ b/patrol/testdata/alias/commits/1/go.mod
@@ -1,0 +1,9 @@
+module github.com/utilitywarehouse/modules
+
+go 1.17
+
+require github.com/sirupsen/logrus v1.8.0
+
+require (
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+)

--- a/patrol/testdata/alias/commits/1/go.sum
+++ b/patrol/testdata/alias/commits/1/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/patrol/testdata/alias/commits/1/main.go
+++ b/patrol/testdata/alias/commits/1/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	log.Debug("hey")
+}

--- a/patrol/testdata/alias/commits/2/changes.patrol
+++ b/patrol/testdata/alias/commits/2/changes.patrol
@@ -1,0 +1,1 @@
+github.com/utilitywarehouse/modules

--- a/patrol/testdata/alias/commits/2/go.mod
+++ b/patrol/testdata/alias/commits/2/go.mod
@@ -1,0 +1,9 @@
+module github.com/utilitywarehouse/modules
+
+go 1.17
+
+require github.com/sirupsen/logrus v1.8.1
+
+require (
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+)

--- a/patrol/testdata/alias/commits/2/go.sum
+++ b/patrol/testdata/alias/commits/2/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/patrol/testdata/alias/commits/2/main.go
+++ b/patrol/testdata/alias/commits/2/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+func main() {
+	log.Debug("hey")
+}

--- a/patrol/testdata/submodules/commits/1/go.mod
+++ b/patrol/testdata/submodules/commits/1/go.mod
@@ -1,0 +1,9 @@
+module github.com/utilitywarehouse/submodules
+
+go 1.17
+
+require github.com/sirupsen/logrus v1.8.0
+
+require (
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+)

--- a/patrol/testdata/submodules/commits/1/go.sum
+++ b/patrol/testdata/submodules/commits/1/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/patrol/testdata/submodules/commits/1/sub/module.go
+++ b/patrol/testdata/submodules/commits/1/sub/module.go
@@ -1,0 +1,9 @@
+package sub
+
+import (
+	"github.com/sirupsen/logrus/hooks/writer"
+)
+
+type A struct {
+	writer.Hook
+}

--- a/patrol/testdata/submodules/commits/2/changes.patrol
+++ b/patrol/testdata/submodules/commits/2/changes.patrol
@@ -1,0 +1,1 @@
+github.com/utilitywarehouse/submodules/sub

--- a/patrol/testdata/submodules/commits/2/go.mod
+++ b/patrol/testdata/submodules/commits/2/go.mod
@@ -1,0 +1,9 @@
+module github.com/utilitywarehouse/submodules
+
+go 1.17
+
+require github.com/sirupsen/logrus v1.8.1
+
+require (
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+)

--- a/patrol/testdata/submodules/commits/2/go.sum
+++ b/patrol/testdata/submodules/commits/2/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/patrol/testdata/submodules/commits/2/sub/module.go
+++ b/patrol/testdata/submodules/commits/2/sub/module.go
@@ -1,0 +1,9 @@
+package sub
+
+import (
+	"github.com/sirupsen/logrus/hooks/writer"
+)
+
+type A struct {
+	writer.Hook
+}


### PR DESCRIPTION
Previously patrol would only catch a dependency upgrade in go.mod if a local package was referring the top-level package in that dependency. For example if your go.mod looked something like:

```
module github.com/your-org/your-module

go 1.17

require github.com/another-org/their-module v1.8.0
```

And you were to upgrade github.com/another-org/their-module to version v1.8.1, only the packages in your module relying on github.com/another-org/their-module would be marked as changed, while packages depending on other nested package in that dependency wouldn't (e.g. github.com/another-org/their-module/writer).

Bonus: a test was added for aliased imports